### PR TITLE
The Next Steps section has the wrong heading level

### DIFF
--- a/help/using/configuring-pipeline.md
+++ b/help/using/configuring-pipeline.md
@@ -198,7 +198,7 @@ On the home screen, these pipelines are listed in a new card:
    >
    >While the pipeline is running, the current step is displayed and only the **Details** action is available.
 
-### The Next Steps {#the-next-steps}
+## The Next Steps {#the-next-steps}
 
 Once you have configured the pipeline, you need to deploy your code.
 


### PR DESCRIPTION
should be H2, not H3

As an H3 is appears nested (in the right navigation) under the Non-Production & Code Quality Only Pipelines section, which is obviously incorrect.