### PR TITLE
Location of Custom variables

### DIFF
--- a/help/getting-started/dispatcher-configurations.md
+++ b/help/getting-started/dispatcher-configurations.md
@@ -24,7 +24,7 @@ Follow these steps below to complete the initial Dispatcher configuration.
 
 1. Obtain the current production configuration files from your CSE.
 1. Remove hard-coded environment-specific data such as publish renderer IP and replace with variables.
-1. Define required variables in key-value pairs for each target Dispatcher and request your CSE to add them to `/etc/sysconfig/httpd` on each instance.
+1. Define required variables in key-value pairs for each target Dispatcher and add them to [variables](https://experienceleague.adobe.com/docs/experience-manager-learn/ams/dispatcher/variables.html?lang=en#where-to-put-the-variables) folder on each instance.
 1. Test the updated configurations on your staging environment.
 1. Once tested, request your CSE to deploy to production.
 1. Commit the files to your git repository.


### PR DESCRIPTION
AMS manual[1] suggests to keep the custom variables in **/etc/httpd/conf.d/variables/** so customers can have control of it. This document corruntly ask customers to put variables into **/etc/sysconfig/httpd** which is only for AMS specific variables and needs CSEs help.
 
[1] https://experienceleague.adobe.com/docs/experience-manager-learn/ams/dispatcher/variables.html?lang=en#variables-files-(.vars)