### PR TITLE
Update build environment details

### DIFF
--- a/help/getting-started/build-environment.md
+++ b/help/getting-started/build-environment.md
@@ -12,7 +12,9 @@ Learn about the specialized build environment that Cloud Manager users to build 
 
 Cloud Manager's build environments have following attributes.
 
-* The build environment is Linux-based, derived from Ubuntu 18.04.
+* The build environment is Linux-based, derived from Ubuntu 22.04.
+* Node 12+ support.
+  * Refer to [frontend-maven-plugin](https://github.com/eirslett/frontend-maven-plugin) for configuration options.
 * Apache Maven 3.8.8 is installed.
 * The Java versions installed are Oracle JDK 8u371 and Oracle JDK 11.0.20.
   * `/usr/lib/jvm/jdk1.8.0_371`


### PR DESCRIPTION
Also includes a note about Node so it is clear that no limitations exist, and a link for configuration via frontend-maven-plugin which is the defacto goto.

This aligns with the Cloud Manager December 2023 release which introduced:
- Ubuntu 22.04
- Node 18+ support